### PR TITLE
박근우 - Products/Tags 관련 API 기능 추가

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -33,7 +33,40 @@ const getProductsDetails = async (req, res) => {
     }
 };
 
+const getTags = async (req, res) => {
+    try {
+        const getTags = await productService.getTags();
+
+        return res.status(200).json(getTags);
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+};
+
+const getProductsByTags = async (req, res) => {
+    try {
+        const tags = req.params.tag_ids.split(',');
+    
+        const numTags = tags.map(str => {
+            return Number(str)
+        });
+
+        if (!tags) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+    
+        const getProductsByTags = await productService.getProductsByTags(numTags);
+    
+        return res.status(200).json({getProductsByTags});
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+    
+}
+
 module.exports = {
     getProductsCovers,
-    getProductsDetails
+    getProductsDetails,
+    getTags,
+    getProductsByTags
 }

--- a/models/productDao.js
+++ b/models/productDao.js
@@ -3,11 +3,11 @@ const {myDataSource} = require('../utils/dataSource');
 const getProductIds = async () => {
         const productIds = await myDataSource.query(
             `SELECT
-                JSON_ARRAYAGG(
+            JSON_ARRAYAGG(
                     id
                 ) AS ids
-             FROM products
-             `);
+        FROM products
+        `);
 
         return productIds[0].ids;
 };
@@ -36,32 +36,87 @@ const getProductCovers = async (limit, offset) => {
         return productInfo;
 };
 
-
 const getProductDetails = async (product_id) => {
-    const productInfo = await myDataSource.query(
+        const id = product_id;
+
+        const productInfo = await myDataSource.query(
             `SELECT 
                 p.id,
                 p.name,
                 p.detail_image_url,
                 p.price,
                 JSON_ARRAYAGG(
-                    t.name
-                ) AS tags
+                        t.name
+                    ) AS tags
             FROM products p
             JOIN tag_bunches tb
             ON tb.product_id = p.id
             INNER JOIN tags t
             ON t.id = tb.tag_id
-            WHERE p.id = ${product_id}
+            WHERE p.id = ${id}
             GROUP BY p.id
             ORDER BY p.id
             `);
-
+    
     return productInfo;
+    
 };
+
+
+const getTags = async () => {
+    const tagInfo = await myDataSource.query(
+        `SELECT 
+            id,
+            name
+        FROM tags
+    `);
+
+    return tagInfo;
+};
+
+const getProductsByTags = async (numTags) => {
+    try {
+        const productIds = await myDataSource.query(
+            `SELECT
+                p.id
+            FROM products p
+            JOIN tag_bunches tb 
+            ON tb.product_id = p.id 
+            JOIN tags t ON t.id = tb.tag_id
+            WHERE t.id IN (${String(numTags)})
+            GROUP BY p.id 
+            HAVING COUNT(*) = ${numTags.length}
+            ORDER BY p.id
+            `);
+
+        const result = await myDataSource.query(
+            `SELECT 
+                p.id, 
+                p.name,
+                JSON_ARRAYAGG(
+                    t.name
+                ) AS tags
+            FROM products p 
+            JOIN tag_bunches tb 
+            ON tb.product_id = p.id 
+            JOIN tags t ON t.id = tb.tag_id
+            WHERE p.id IN (${productIds.map(obj => {return obj.id})})
+            GROUP BY p.id 
+            ORDER BY p.id`
+        );
+        
+        return result;
+    } catch (err) {
+        const error = new Error("SOMETHING IS WRONG");
+        error.statusCode = 500;
+        throw error;
+    }
+}
 
 module.exports = {
     getProductIds,
+    getTags,
     getProductCovers,
-    getProductDetails
+    getProductDetails,
+    getProductsByTags
 }

--- a/routes/productRouter.js
+++ b/routes/productRouter.js
@@ -4,7 +4,9 @@ const productController = require('../controllers/productController');
 const router = express.Router();
 
 router.get('/', productController.getProductsCovers);
-router.get('/:product_id', productController.getProductsDetails);
+router.get('/:product_id(\\d+)', productController.getProductsDetails);
+router.get('/tags/', productController.getTags);
+router.get('/tags/:tag_ids', productController.getProductsByTags);
 
 module.exports = {
     router

--- a/services/productService.js
+++ b/services/productService.js
@@ -19,15 +19,34 @@ const getProductsDetails = async (product_id) => {
     const getProductDetails = await productDao.getProductDetails(product_id);
     
     if (!getProductDetails[0]) {
-        const err = new Error("NO_SUCH_PRODUCT_ID");
+        const err = new Error("NO_SUCH_DATA");
         err.statusCode = 404;
         throw err;
     }
 
     return getProductDetails;
+}
+
+const getTags = async () => {
+    const getTags = await productDao.getTags();
+
+    return getTags;
 };
 
+const getProductsByTags = async (numTags) => {
+    const getProductsByTags = await productDao.getProductsByTags(numTags);
+    
+    if (!getProductsByTags) {
+        const err = new Error('NO_SUCH_DATA');
+        err.statusCode = 404;
+        throw err;
+    }
+
+    return getProductsByTags;
+}
 module.exports = {
     getProductsCovers,
-    getProductsDetails
+    getProductsDetails,
+    getTags,
+    getProductsByTags
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Products와 밀접한 관계가 있는 Tags 관련 기능을 추가했습니다. 시간적 여유가 있었다면 getTags와 getProductsByTags를 분리하여 commit 하고싶지만 현재 시간적 여유가 조금 부족하고 getTags의 기능이 워낙에 단순하고 간단합니다. 그리고 어제 PR로 getProductsByTags의 refactoring관련 피드백도 있었기에 두 개를 같이 커밋했습니다!
1. getTags: 현재 DB 내의 tags 표에 존재하는 모든 tag들의 이름과 ID를 반환.
2. getProductsByTags: 현재 DB 내의 products와 tag_bunches와 tags 내의 데이터들을 모아 프론트엔드 개발자 분들이 다루시기 편한 형태로 반환.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. getTags: 모든 태그의 정보 반환
- products/tags로 GET method를 사용하여 요청
- SQL 쿼리: SELECT로 tags의 ID와 태그 이름들을 객체로 담은 배열을 반환.

2. getProductsByTags: 상품 ID, 이름, 가격, 커버 사진 url, 해당 상품에 연결된 태그들을 반환.
- products/tags/:tag_ids에 :tag_ids 대신 태그 아이디 리스트를 입력하여 GET method로 요청.
- SQL 쿼리: SELECT로 해당 태그 아이디들을 모두 가지고 있는 상품의 ID들만 골라내어 그 상품 ID를 가진 상품들의 기본 정보만 반환.
- 
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- query문에 대한 자유도
- JOIN과 INNER JOIN, JSON_ARRAYAGG와 JSON_OBJECT에 대한 이해도 상승.
<br />

## :: 기타 질문 및 특이 사항
- 필요한 query문을 검색할 때 키워드 잡기가 쉽지 않습니다. 예를 들어, getProductsByTags에 사용할 쿼리문을 검색할 때, "Intersecting version of SQL Query IN", "How to select rows with certain values", "SQL query recursive loop" 등으로 여러가지 쿼리 방법을 검색해봤지만 HAVING COUNT(*)는 나오지 않았습니다. 키워드를 잡는 데에 도움이 되는 리소스나 사고 방식이 있을까요?
