### PR TITLE
박근우-주문 전체 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ utils/tags.CSV
 utils/tag_bunches.CSV
 utils/csvImporter.js
 utils/queryManager.js
+utils/status.CSV
+utils/users.CSV
+utils/user_addresses.CSV

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -1,0 +1,106 @@
+const orderService = require('../services/orderService');
+
+const postOrders = async (req, res) => {
+    try {
+        const {user_id, status_order_id, user_address_id} = req.body;
+
+        if (!user_id || !status_order_id || !user_address_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+
+        const postOrders = await orderService.postOrders(user_id, status_order_id, user_address_id);
+
+        return res.status(201).json({data : postOrders});
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+};
+
+const postOrderItems = async (req, res) => {
+    try {
+        const {product_id, status_order_item_id, amount, order_id} = req.body;
+
+        if (!product_id || !status_order_item_id || !amount || !order_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+
+        const postOrderItems = await orderService.postOrderItems(product_id, status_order_item_id, amount, order_id);
+
+        return res.status(200).json({data: postOrderItems});
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+};
+
+const getOrderByOrderId = async (req, res) => {
+    try {
+        const {order_id} = req.params;
+
+        if (!order_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+
+        const getOrderByOrderId = await orderService.getOrderByOrderId(order_id);
+        
+        return res.status(201).json(getOrderByOrderId);
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+};
+
+const getOrderItemByOrderItemId = async (req, res) => {
+    try {
+        const {order_item_id} = req.params;
+
+        if (!order_item_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+
+        const getOrderItemByOrderItemId = await orderService.getOrderItemByOrderItemId(order_item_id);
+        
+        return res.status(201).json(getOrderItemByOrderItemId);
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+};
+
+const deleteOrders = async (req, res) => {
+    try {
+        const {order_id} = req.params;
+
+        if (!order_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+
+        await orderService.deleteOrders(order_id);
+
+        return res.status(200).json({message: 'orderDeleted'});
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+};
+
+const deleteOrderItems = async (req, res) => {
+    try {
+        const {order_item_id} = req.params;
+
+        if (!order_item_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+
+        await orderService.deleteOrderItems(order_item_id);
+
+        return res.status(200).json({message: 'orderItemDeleted'});
+    } catch (err) {
+        return res.status(err.statusCode || 500).json({message: err.message});
+    }
+};
+
+module.exports = {
+    postOrders,
+    postOrderItems,
+    getOrderByOrderId,
+    getOrderItemByOrderItemId,
+    deleteOrders,
+    deleteOrderItems
+}

--- a/models/orderDao.js
+++ b/models/orderDao.js
@@ -1,7 +1,6 @@
 const {myDataSource} = require('../utils/dataSource');
 
 const allUserIds = async () => {
-    try {
         const userIds = await myDataSource.query(
                 `SELECT
                     JSON_ARRAYAGG(
@@ -11,15 +10,9 @@ const allUserIds = async () => {
         );
 
         return userIds[0].ids;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const allStatusOrderIds = async () => {
-    try {
         const statusOrderIds = await myDataSource.query(
                 `SELECT
                     JSON_ARRAYAGG(
@@ -29,15 +22,9 @@ const allStatusOrderIds = async () => {
         );
 
         return statusOrderIds[0].ids;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const allAddressIdsOfUserId = async (user_id) => {
-    try {
         const addressIdsOfUserId = await myDataSource.query(
                 `SELECT
                     JSON_ARRAYAGG(
@@ -48,15 +35,9 @@ const allAddressIdsOfUserId = async (user_id) => {
         );
     
         return addressIdsOfUserId[0].ids;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const postOrders = async (user_id, status_order_id, user_address_id) => {
-    try {
         const postOrders = await myDataSource.query(
             `INSERT INTO orders(
                 user_id,
@@ -68,15 +49,9 @@ const postOrders = async (user_id, status_order_id, user_address_id) => {
         );
 
         return postOrders['insertId'];
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const allProductIds = async () => {
-    try {
         const productIds = await myDataSource.query(
             `SELECT
                 JSON_ARRAYAGG(
@@ -86,15 +61,9 @@ const allProductIds = async () => {
         );
 
         return productIds[0].ids;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const allStatusOrderItemIds = async () => {
-    try {
         const statusOrderItemIds = await myDataSource.query(
             `SELECT 
                 JSON_ARRAYAGG(
@@ -104,15 +73,9 @@ const allStatusOrderItemIds = async () => {
         );
 
         return statusOrderItemIds[0].ids;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const allOrderItemIds = async () => {
-    try {
         const orderItemIds = await myDataSource.query(
             `SELECT
                 JSON_ARRAYAGG(
@@ -122,15 +85,9 @@ const allOrderItemIds = async () => {
         );
 
         return orderItemIds[0].ids;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const getProductStock = async (product_id) => {
-    try {
         const stockOfProductId = await myDataSource.query(
             `SELECT
                 stock
@@ -141,15 +98,9 @@ const getProductStock = async (product_id) => {
         const stock = stockOfProductId[0].stock;
 
         return stock;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const postOrderItems = async (product_id, status_order_item_id, amount, order_id) => {
-    try {
         const postOrderItems = await myDataSource.query(
             `INSERT INTO order_items(
                 product_id,
@@ -162,15 +113,9 @@ const postOrderItems = async (product_id, status_order_item_id, amount, order_id
         );
 
         return postOrderItems['insertId'];
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const allOrderIds = async () => {
-    try {
         const orderIds = await myDataSource.query(
             `SELECT
                 JSON_ARRAYAGG(
@@ -180,15 +125,9 @@ const allOrderIds = async () => {
         );
 
         return orderIds[0].ids;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const getOrderByOrderId = async (order_id) => {
-    try {
         const orderOfOrderId = await myDataSource.query(
             `SELECT
                 o.id AS order_id,
@@ -209,15 +148,9 @@ const getOrderByOrderId = async (order_id) => {
         );
         
         return orderOfOrderId;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const getOrderItemByOrderItemId = async (order_item_id) => {
-    try {
         const orderItemByOrderItemId = await myDataSource.query(
             `SELECT
                 oi.id AS order_item_id,
@@ -238,43 +171,26 @@ const getOrderItemByOrderItemId = async (order_item_id) => {
         );
 
         return orderItemByOrderItemId;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 // ------------------------- LINE 77 ----------------------------
 
 const deleteOrders = async (order_id) => {
-    try {
         const deleteOrders = await myDataSource.query(
             `DELETE FROM orders
             WHERE orders.id = ${order_id}`
         );
 
         return deleteOrders;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 const deleteOrderItems = async (order_item_id) => {
-    try {
         const deleteOrderItems = await myDataSource.query(
             `DELETE FROM order_items
             WHERE order_items.id = ${order_item_id}`
         );
 
         return deleteOrderItems;
-    } catch (err) {
-        const error = new Error('SOMETHING IS WRONG');
-        error.statusCode = 500;
-        throw err;
-    }
 };
 
 module.exports = {

--- a/models/orderDao.js
+++ b/models/orderDao.js
@@ -1,0 +1,296 @@
+const {myDataSource} = require('../utils/dataSource');
+
+const allUserIds = async () => {
+    try {
+        const userIds = await myDataSource.query(
+                `SELECT
+                    JSON_ARRAYAGG(
+                        users.id
+                    ) AS ids
+                FROM users`
+        );
+
+        return userIds[0].ids;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const allStatusOrderIds = async () => {
+    try {
+        const statusOrderIds = await myDataSource.query(
+                `SELECT
+                    JSON_ARRAYAGG(
+                        id
+                    ) AS ids
+                FROM status_orders`
+        );
+
+        return statusOrderIds[0].ids;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const allAddressIdsOfUserId = async (user_id) => {
+    try {
+        const addressIdsOfUserId = await myDataSource.query(
+                `SELECT
+                    JSON_ARRAYAGG(
+                        id
+                    ) AS ids
+                FROM user_addresses
+                WHERE user_id = ${user_id}`
+        );
+    
+        return addressIdsOfUserId[0].ids;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const postOrders = async (user_id, status_order_id, user_address_id) => {
+    try {
+        const postOrders = await myDataSource.query(
+            `INSERT INTO orders(
+                user_id,
+                status_order_id,
+                user_address_id
+            ) VALUES (?, ?, ?);
+            `,
+            [user_id, status_order_id, user_address_id]
+        );
+
+        return postOrders['insertId'];
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const allProductIds = async () => {
+    try {
+        const productIds = await myDataSource.query(
+            `SELECT
+                JSON_ARRAYAGG(
+                    id
+                ) AS ids
+            FROM products`
+        );
+
+        return productIds[0].ids;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const allStatusOrderItemIds = async () => {
+    try {
+        const statusOrderItemIds = await myDataSource.query(
+            `SELECT 
+                JSON_ARRAYAGG(
+                    id
+                ) AS ids
+            FROM status_order_items`
+        );
+
+        return statusOrderItemIds[0].ids;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const allOrderItemIds = async () => {
+    try {
+        const orderItemIds = await myDataSource.query(
+            `SELECT
+                JSON_ARRAYAGG(
+                    id
+                ) AS ids 
+            FROM order_items`
+        );
+
+        return orderItemIds[0].ids;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const getProductStock = async (product_id) => {
+    try {
+        const stockOfProductId = await myDataSource.query(
+            `SELECT
+                stock
+            FROM products
+            WHERE id = ${product_id}`
+        );
+        
+        const stock = stockOfProductId[0].stock;
+
+        return stock;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const postOrderItems = async (product_id, status_order_item_id, amount, order_id) => {
+    try {
+        const postOrderItems = await myDataSource.query(
+            `INSERT INTO order_items(
+                product_id,
+                status_order_item_id,
+                amount,
+                order_id
+            ) VALUES (?, ?, ?, ?)
+            `,
+            [product_id, status_order_item_id, amount, order_id]
+        );
+
+        return postOrderItems['insertId'];
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const allOrderIds = async () => {
+    try {
+        const orderIds = await myDataSource.query(
+            `SELECT
+                JSON_ARRAYAGG(
+                    id
+                ) AS ids
+            FROM orders`
+        );
+
+        return orderIds[0].ids;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const getOrderByOrderId = async (order_id) => {
+    try {
+        const orderOfOrderId = await myDataSource.query(
+            `SELECT
+                o.id AS order_id,
+                o.user_id AS order_user_id,
+                o.status_order_id AS order_status_id,
+                o.user_address_id AS order_user_address_id,
+                u.name AS user_name,
+                so.name AS status_name,
+                ua.address AS user_address
+            FROM orders o
+            INNER JOIN users u
+            ON u.id = o.user_id
+            INNER JOIN status_orders so
+            ON so.id = o.status_order_id
+            INNER JOIN user_addresses ua
+            ON ua.id = o.user_address_id
+            WHERE o.id = ${order_id}`
+        );
+        
+        return orderOfOrderId;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const getOrderItemByOrderItemId = async (order_item_id) => {
+    try {
+        const orderItemByOrderItemId = await myDataSource.query(
+            `SELECT
+                oi.id AS order_item_id,
+                oi.amount AS order_item_amount,
+                oi.product_id AS order_item_product_id,
+                oi.status_order_item_id AS order_item_status_id,
+                oi.order_id AS order_item_order_id,
+                p.name AS product_name,
+                p.cover_image_url AS product_cover_image_url,
+                p.price AS product_price,
+                soi.name AS status_name
+            FROM order_items oi
+            INNER JOIN products p
+            ON p.id = oi.product_id
+            INNER JOIN status_order_items soi
+            ON soi.id = oi.status_order_item_id
+            WHERE oi. id = ${order_item_id}`
+        );
+
+        return orderItemByOrderItemId;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+// ------------------------- LINE 77 ----------------------------
+
+const deleteOrders = async (order_id) => {
+    try {
+        const deleteOrders = await myDataSource.query(
+            `DELETE FROM orders
+            WHERE orders.id = ${order_id}`
+        );
+
+        return deleteOrders;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+const deleteOrderItems = async (order_item_id) => {
+    try {
+        const deleteOrderItems = await myDataSource.query(
+            `DELETE FROM order_items
+            WHERE order_items.id = ${order_item_id}`
+        );
+
+        return deleteOrderItems;
+    } catch (err) {
+        const error = new Error('SOMETHING IS WRONG');
+        error.statusCode = 500;
+        throw err;
+    }
+};
+
+module.exports = {
+    allUserIds,
+    allStatusOrderIds,
+    allAddressIdsOfUserId,
+    postOrders,
+    allProductIds,
+    allStatusOrderItemIds,
+    allOrderItemIds,
+    getProductStock,
+    postOrderItems,
+    allOrderIds,
+    getOrderByOrderId,
+    allOrderItemIds,
+    getOrderItemByOrderItemId,
+    deleteOrders,
+    deleteOrderItems
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,9 +3,12 @@ const router = express.Router();
 const productRouter = require('./productRouter');
 const userRouter = require('./userRouter');
 const cartRouter = require("./cartRouter");
+const orderRouter = require("./orderRouter");
 
 router.use('', productRouter.router);
 router.use('/users', userRouter.router);
+router.use('/products', productRouter.router);
 router.use('/carts', cartRouter.router);
+router.use('/orders', orderRouter.router);
 
 module.exports =router

--- a/routes/orderRouter.js
+++ b/routes/orderRouter.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const orderController = require('../controllers/orderController');
+const jwt = require("../utils/jwt");
+
+const router = express.Router();
+
+router.post("", jwt.validationToken, orderController.postOrders);
+router.post("/items", jwt.validationToken,orderController.postOrderItems);
+router.get("/:order_id(\\d+)", jwt.validationToken, orderController.getOrderByOrderId);
+router.get("/item/:order_item_id", jwt.validationToken, orderController.getOrderItemByOrderItemId);
+router.delete("/:order_id", jwt.validationToken, orderController.deleteOrders);
+router.delete("/item/:order_item_id", jwt.validationToken, orderController.deleteOrderItems);
+
+module.exports = {
+    router
+}

--- a/services/orderService.js
+++ b/services/orderService.js
@@ -1,0 +1,109 @@
+const orderDao = require('../models/orderDao');
+
+const postOrders = async (user_id, status_order_id, user_address_id) => {
+    const allUserIds = await orderDao.allUserIds();
+    const allStatusOrderIds = await orderDao.allStatusOrderIds();
+
+    if (!allUserIds.includes(user_id) || !allStatusOrderIds.includes(status_order_id)) {
+        const err = new Error("NO_SUCH_USER_OR_STATUS");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const allAddressIdsOfUserId = await orderDao.allAddressIdsOfUserId(user_id);
+
+    if (!allAddressIdsOfUserId.includes(user_address_id)) {
+        const err = new Error("NO_SUCH_ADDRESS");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const postOrders = await orderDao.postOrders(user_id, status_order_id, user_address_id);
+
+    return postOrders;
+};
+
+
+const postOrderItems = async(product_id, status_order_item_id, amount, order_id) => {
+    const allProductIds = await orderDao.allProductIds();
+    const allStatusOrderItemIds = await orderDao.allStatusOrderItemIds();
+  
+    if (!allProductIds.includes(product_id) || !allStatusOrderItemIds.includes(status_order_item_id)) {
+        const err = new Error("NO_SUCH_PRODUCT_OR_STATUS_OR_ORDER");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const getProductStock = await orderDao.getProductStock(product_id);
+
+    if (getProductStock < amount) {
+        const err = new Error("NO_MORE_STOCK");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const postOrderItems = await orderDao.postOrderItems(product_id, status_order_item_id, amount, order_id);
+
+    return postOrderItems;
+};
+
+const getOrderByOrderId = async (order_id) => {
+    const getOrderByOrderId = await orderDao.getOrderByOrderId(order_id);
+
+    if (!getOrderByOrderId[0]) {
+        const err = new Error("NO_SUCH_ORDER");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    return getOrderByOrderId;
+};
+
+const getOrderItemByOrderItemId = async (order_item_id) => {
+    const getOrderItemByOrderItemId = await orderDao.getOrderItemByOrderItemId(order_item_id);
+
+    if (!getOrderItemByOrderItemId[0]) {
+        const err = new Error("NO_SUCH_ORDER_ITEM");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    return getOrderItemByOrderItemId;
+}
+
+const deleteOrders = async (order_id) => {
+    const allOrderIds = await orderDao.allOrderIds();
+
+    if (allOrderIds == null || !allOrderIds.includes(Number(order_id))) {
+        const err = new Error("NO_SUCH_ORDER_TO_DELETE");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const deleteOrders = await orderDao.deleteOrders(order_id);
+
+    return deleteOrders;
+}
+
+const deleteOrderItems = async (order_item_id) => {
+    const allOrderItemIds = await orderDao.allOrderItemIds();
+
+    if (allOrderItemIds == null || !allOrderItemIds.includes(Number(order_item_id))) {
+        const err = new Error("NO_SUCH_ORDER_ITEM_TO_DELETE");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const deleteOrderItems = await orderDao.deleteOrderItems(order_item_id);
+
+    return deleteOrderItems;
+}
+
+module.exports = {
+    postOrders,
+    postOrderItems,
+    getOrderByOrderId,
+    getOrderItemByOrderItemId,
+    deleteOrders,
+    deleteOrderItems
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- order API 모음
1. 구매 묶음 추가
2. 구매 상품 추가
3. 구매 묶음 조회
4. 구매 상품 조회
5. 구매 묶음 제거
6. 구매 상품 제거

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 구매 묶음 추가
- POST/orders로 request body에 유저ID, 구매 묶음 배송 상태ID, 유저 주소ID를 담아 요청을 받음.
- orders 표에 request body에 있는 데이터를 추가하고 해당 구매 묶음의 ID를 response에 json 형태로 담아 반환

2. 구매 상품 추가
- POST/orders/items로 request body에 상품ID, 구매 개수, 구매 상품의 배송 상태ID, 구매 상품이 속한 구매 묶음ID를 담아 요청을 받음.
- orders 표에 request body에 있는 데이터를 추가하고 해당 구매 상품의 ID를 response에 json 형태로 담아 반환.

3. 구매 묶음 조회
- GET/orders로 request Parameter에 원하는 구매 묶음 ID를 담아 요청을 받음.
- 해당 구매 묶음ID, 유저ID와 이름, 구매 묶음 배송 상태ID와 상태(문자열), 유저 주소ID와 주소(문자열)을 반환.

4. 구매 상품 조회
- GET/orders/item로 request Parameter에 원하는 구매 상품 ID를 담아 요청을 받음.
- 해당 구매 상품ID, 상품ID와 이름, 상품 배송 상태ID와 상태(문자열), 개수, 개당 가격, 대표 사진 url등을 담아 반환

5. 구매 묶음 삭제
- DELETE/orders로 request Parameter에 원하는 구매 묶음 ID를 담아 요청을 받음.
- 해당 구매 묶음 ID를 가진 구매 묶음을 orders에서 삭제.
- 해당 구매 묶음에 속한 구매 상품들 또한 삭제.

6. 구매 상품 삭제
- DELETE/orders/item로 request Parameter에 원하는 구매 상품 ID를 담아 요청을 받음.
- 해당 구매 상품 ID를 가진 구매 상품을 order_items에서 삭제.
 
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
1. GitHub remote merge의 순서에 대한 고민.
- 실무에선 극히 낮은 확률로 일어날 수도 있는 상황이지만, 현재는 처음으로 팀프로젝트를 해보는 인원끼리 작업을 했기 때문에 remote merge의 순서에 대한 고민을 초반에 미쳐 하지 못하고 이미 몇개의 브랜치가 merge 된 이후에 해봤습니다. 그래서, 작업 순서가 엉키고, 작업 속도가 늦어졌습니다. 다음 프로젝트 부터는 이런 문제를 인식하고 PR 순서를 정하여, 순서가 엉키지 않기 위해 PR에 merge priority를 적어놓는 등의 시도를 해보는 것이 좋겠습니다.


<br />

## :: 기타 질문 및 특이 사항
- N/A
